### PR TITLE
language fix, instrinsic > intrinsic

### DIFF
--- a/docs/gufo.ttl
+++ b/docs/gufo.ttl
@@ -1003,7 +1003,7 @@ Examples include intrinsic physical aspects, such as the Moon's mass, Lassie's f
 
 A gufo:IntrinsicAspect is classified as a gufo:Quality (e.g., an apple's weight, the height of the Statue of Liberty) if it is measurable by a certain value space, or as a gufo:IntrinsicMode (e.g. Bob's belief that the Eiffel Tower is in Paris) otherwise.
 
-Corresponds to \"Instrinsic Moment\" in Guizzardi (2005). Different from Guizzardi (2005), here we consider that aspects can inhere in concrete individuals in general, and not only in endurants."""@en ;
+Corresponds to \"Intrinsic Moment\" in Guizzardi (2005). Different from Guizzardi (2005), here we consider that aspects can inhere in concrete individuals in general, and not only in endurants."""@en ;
                      rdfs:label "IntrinsicAspect"@en ;
                      rdfs:seeAlso gufo:inheresIn .
 
@@ -1112,7 +1112,7 @@ gufo:Phase rdf:type owl:Class ;
            rdfs:subClassOf gufo:AntiRigidType ,
                            gufo:Sortal ;
            owl:disjointWith gufo:Role ;
-           rdfs:comment """A gufo:EndurantType that is both sortal and anti-rigid. It is defined by instrinsic but contingent instantiation conditions. Phases are relationally independent types that capturec instrinsic properties shared by instances of a given kind.
+           rdfs:comment """A gufo:EndurantType that is both sortal and anti-rigid. It is defined by intrinsic but contingent instantiation conditions. Phases are relationally independent types that capturec intrinsic properties shared by instances of a given kind.
 
 For example, \"Child\" may be considered a gufo:Phase as a subclass of the gufo:Kind \"Person\", instantiated by persons younger than 12. Another example is the type \"IllPerson\", which may be considered a gufo:Phase that is instantiated whenever an instance of \"Disease\" (a gufo:IntrinsicMode) inheres in a person."""@en ;
            rdfs:label "Phase"@en .
@@ -1123,7 +1123,7 @@ gufo:PhaseMixin rdf:type owl:Class ;
                 rdfs:subClassOf gufo:AntiRigidType ,
                                 gufo:NonSortal ;
                 owl:disjointWith gufo:RoleMixin ;
-                rdfs:comment """A gufo:EndurantType that is both non-sortal and anti-rigid. It is defined by instrinsic but contingent instantiation conditions. Phase mixins are relationally independent types that capture instrinsic properties shared by instances of different kinds.
+                rdfs:comment """A gufo:EndurantType that is both non-sortal and anti-rigid. It is defined by intrinsic but contingent instantiation conditions. Phase mixins are relationally independent types that capture intrinsic properties shared by instances of different kinds.
 
 For example, \"LivingAnimal\" may be considered a gufo:PhaseMixin as a superclass of the phases \"LivingPerson\" (specializing the gufo:Kind \"Person\") and \"LivingDog\" (specializing the gufo:Kind \"Dog\")."""@en ;
                 rdfs:label "PhaseMixin"@en .

--- a/docs/index.html
+++ b/docs/index.html
@@ -225,7 +225,7 @@ PhD Thesis, University of Twente, The Netherlands, 2005. <a href="https://resear
 <ul>
 <li>Endurant<ul>
 <li>Aspect<ul>
-<li>InstrinsicAspect<ul>
+<li>IntrinsicAspect<ul>
 <li>Quality</li>
 <li>IntrinsicMode</li>
 </ul>
@@ -1214,7 +1214,7 @@ PhD Thesis, University of Twente, The Netherlands, 2005. <a href="https://resear
                     <p>A <a href="#Aspect">gufo:Aspect</a> that depends on a single concrete individual in which it inheres. </p>
 <p>Examples include intrinsic physical aspects, such as the Moon's mass, Lassie's fur color; the fragility of John Lennon's glasses; mental dispositions, such as Bob's math skills, his belief that the number one is odd.</p>
 <p>A <a href="#IntrinsicAspect">gufo:IntrinsicAspect</a> is classified as a <a href="#Quality">gufo:Quality</a> (e.g., an apple's weight, the height of the Statue of Liberty) if it is measurable by a certain value space, or as a <a href="#IntrinsicMode">gufo:IntrinsicMode</a> (e.g. Bob's belief that the Eiffel Tower is in Paris) otherwise.</p>
-<p>Corresponds to "Instrinsic Moment" in Guizzardi (2005). Different from Guizzardi (2005), here we consider that aspects can inhere in concrete individuals in general, and not only in endurants.</p>
+<p>Corresponds to "Intrinsic Moment" in Guizzardi (2005). Different from Guizzardi (2005), here we consider that aspects can inhere in concrete individuals in general, and not only in endurants.</p>
                 </td>
             </tr>
             <tr>
@@ -2139,7 +2139,7 @@ PhD Thesis, University of Twente, The Netherlands, 2005. <a href="https://resear
             <tr>
                 <th>Description</th>
                 <td>
-                    <p>A <a href="#EndurantType">gufo:EndurantType</a> that is both sortal and anti-rigid. It is defined by instrinsic but contingent instantiation conditions. Phases are relationally independent types that capturec instrinsic properties shared by instances of a given kind.</p>
+                    <p>A <a href="#EndurantType">gufo:EndurantType</a> that is both sortal and anti-rigid. It is defined by intrinsic but contingent instantiation conditions. Phases are relationally independent types that capturec intrinsic properties shared by instances of a given kind.</p>
 <p>For example, "Child" may be considered a <a href="#Phase">gufo:Phase</a> as a subclass of the <a href="#Kind">gufo:Kind</a> "Person", instantiated by persons younger than 12. Another example is the type "IllPerson", which may be considered a <a href="#Phase">gufo:Phase</a> that is instantiated whenever an instance of "Disease" (a <a href="#IntrinsicMode">gufo:IntrinsicMode</a>) inheres in a person.</p>
                 </td>
             </tr>
@@ -2263,7 +2263,7 @@ PhD Thesis, University of Twente, The Netherlands, 2005. <a href="https://resear
             <tr>
                 <th>Description</th>
                 <td>
-                    <p>A <a href="#EndurantType">gufo:EndurantType</a> that is both non-sortal and anti-rigid. It is defined by instrinsic but contingent instantiation conditions. Phase mixins are relationally independent types that capture instrinsic properties shared by instances of different kinds.</p>
+                    <p>A <a href="#EndurantType">gufo:EndurantType</a> that is both non-sortal and anti-rigid. It is defined by intrinsic but contingent instantiation conditions. Phase mixins are relationally independent types that capture intrinsic properties shared by instances of different kinds.</p>
 <p>For example, "LivingAnimal" may be considered a <a href="#PhaseMixin">gufo:PhaseMixin</a> as a superclass of the phases "LivingPerson" (specializing the <a href="#Kind">gufo:Kind</a> "Person") and "LivingDog" (specializing the <a href="#Kind">gufo:Kind</a> "Dog").</p>
                 </td>
             </tr>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -167,7 +167,7 @@ Reified aspects in gUFO are further divided into intrinsic aspects (qualities an
 
 > * Endurant
 >     * Aspect
->         * InstrinsicAspect
+>         * IntrinsicAspect
 >             * Quality
 >             * IntrinsicMode
 >         * ExtrinsicAspect

--- a/gufo.ttl
+++ b/gufo.ttl
@@ -1003,7 +1003,7 @@ Examples include intrinsic physical aspects, such as the Moon's mass, Lassie's f
 
 A gufo:IntrinsicAspect is classified as a gufo:Quality (e.g., an apple's weight, the height of the Statue of Liberty) if it is measurable by a certain value space, or as a gufo:IntrinsicMode (e.g. Bob's belief that the Eiffel Tower is in Paris) otherwise.
 
-Corresponds to \"Instrinsic Moment\" in Guizzardi (2005). Different from Guizzardi (2005), here we consider that aspects can inhere in concrete individuals in general, and not only in endurants."""@en ;
+Corresponds to \"Intrinsic Moment\" in Guizzardi (2005). Different from Guizzardi (2005), here we consider that aspects can inhere in concrete individuals in general, and not only in endurants."""@en ;
                      rdfs:label "IntrinsicAspect"@en ;
                      rdfs:seeAlso gufo:inheresIn .
 
@@ -1112,7 +1112,7 @@ gufo:Phase rdf:type owl:Class ;
            rdfs:subClassOf gufo:AntiRigidType ,
                            gufo:Sortal ;
            owl:disjointWith gufo:Role ;
-           rdfs:comment """A gufo:EndurantType that is both sortal and anti-rigid. It is defined by instrinsic but contingent instantiation conditions. Phases are relationally independent types that capturec instrinsic properties shared by instances of a given kind.
+           rdfs:comment """A gufo:EndurantType that is both sortal and anti-rigid. It is defined by intrinsic but contingent instantiation conditions. Phases are relationally independent types that capturec intrinsic properties shared by instances of a given kind.
 
 For example, \"Child\" may be considered a gufo:Phase as a subclass of the gufo:Kind \"Person\", instantiated by persons younger than 12. Another example is the type \"IllPerson\", which may be considered a gufo:Phase that is instantiated whenever an instance of \"Disease\" (a gufo:IntrinsicMode) inheres in a person."""@en ;
            rdfs:label "Phase"@en .
@@ -1123,7 +1123,7 @@ gufo:PhaseMixin rdf:type owl:Class ;
                 rdfs:subClassOf gufo:AntiRigidType ,
                                 gufo:NonSortal ;
                 owl:disjointWith gufo:RoleMixin ;
-                rdfs:comment """A gufo:EndurantType that is both non-sortal and anti-rigid. It is defined by instrinsic but contingent instantiation conditions. Phase mixins are relationally independent types that capture instrinsic properties shared by instances of different kinds.
+                rdfs:comment """A gufo:EndurantType that is both non-sortal and anti-rigid. It is defined by intrinsic but contingent instantiation conditions. Phase mixins are relationally independent types that capture intrinsic properties shared by instances of different kinds.
 
 For example, \"LivingAnimal\" may be considered a gufo:PhaseMixin as a superclass of the phases \"LivingPerson\" (specializing the gufo:Kind \"Person\") and \"LivingDog\" (specializing the gufo:Kind \"Dog\")."""@en ;
                 rdfs:label "PhaseMixin"@en .


### PR DESCRIPTION
The term "instrinsic" is incorrect. So, I corrected it to "intrinsic" across all the documents where it appears.