### PR TITLE
docs: fix typo isObjectPropertPartOf -> isObjectProperPartOf

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -188,7 +188,7 @@ PhD Thesis, University of Twente, The Netherlands, 2005. <a href="https://resear
 <p>A gufo:FunctionalComplex is a complex gufo:Object whose parts (components) play different roles in its composition, including most ordinary objects. For example, a person could be considered a gufo:FunctionalComplex with the various organs (heart, brain, lungs, etc.) playing different roles.</p>
 <p>A gufo:Collection is a complex gufo:Object whose parts (the members of the collection) have a uniform structure (i.e., members are conceived as playing the same role in the collection). Examples include a deck of cards, a pile of bricks, a forest (conceived as a collection of trees), a group of people. Collections may have a variable or fixed membership (see subclasses gufo:VariableCollection and gufo:FixedCollection).</p>
 <p>A gufo:Quantity is complex gufo:Object that is a maximally-connected portion of stuff. A gufo:Quantity has a fixed constitution, and thus, removing or adding a sub-quantity would result in a different quantity. Examples include the portion of wine in a wine tank, a lump of clay, the gold that constitutes a wedding ring.</p>
-<p>The relations between a part and its whole are captured with the gufo:isObjectPropertPartOf property and its sub-properties, depending on the types of parts and complex objects involved:</p>
+<p>The relations between a part and its whole are captured with the gufo:isObjectProperPartOf property and its sub-properties, depending on the types of parts and complex objects involved:</p>
 <blockquote>
 <ul>
 <li>isObjectProperPartOf<ul>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -130,7 +130,7 @@ A gufo:Collection is a complex gufo:Object whose parts (the members of the colle
 
 A gufo:Quantity is complex gufo:Object that is a maximally-connected portion of stuff. A gufo:Quantity has a fixed constitution, and thus, removing or adding a sub-quantity would result in a different quantity. Examples include the portion of wine in a wine tank, a lump of clay, the gold that constitutes a wedding ring.
 
-The relations between a part and its whole are captured with the gufo:isObjectPropertPartOf property and its sub-properties, depending on the types of parts and complex objects involved:
+The relations between a part and its whole are captured with the gufo:isObjectProperPartOf property and its sub-properties, depending on the types of parts and complex objects involved:
 
 > * isObjectProperPartOf
 >     * isComponentOf - when the part is a component of a funcional complex


### PR DESCRIPTION
## Summary
Fixes a typo in the property name documentation.

## Related Issue
Fixes #53

## Changes
- Fixed `isObjectPropertPartOf` → `isObjectProperPartOf` in:
  - `docs/overview.md`
  - `docs/index.html`

The property name was missing an 'r' (Propert → Proper).